### PR TITLE
Update miniz_zip.c to prevent compilation warning when compiling for Windows in straight C mode

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -42,6 +42,9 @@ extern "C" {
 #if defined(_MSC_VER) || defined(__MINGW64__) || defined(__MINGW32__)
 
 #define WIN32_LEAN_AND_MEAN
+#ifndef __cplusplus
+#define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS 0
+#endif
 #include <windows.h>
 
 static WCHAR* mz_utf8z_to_widechar(const char* str)


### PR DESCRIPTION

### Summary:
Added conditional macro definition to prevent MSVC compiler warning C5105 when compiling for Windows in straight C mode

### Details:
Since version 3.0.0 miniz_zip.c includes windows.h header file when compiling for Windows using MSVC. However, when compiling miniz_zip.c using MSVC17 in straight-C mode (no C++), this inclusion causes warning C5105:

> winbase.h(9531,5): warning C5105: macro expansion producing 'defined' has undefined behavior

This warning is not produced when compiling in C++ mode.

In order to prevent the warning, any straight-C code that wants to include windows.h should make an additional define before including:
```
#ifndef __cplusplus
#define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS 0 #endif
#include <windows.h>
```