### PR TITLE
Prevent min/max conflicts between windows.h and std namespace

### DIFF
--- a/miniz_zip.c
+++ b/miniz_zip.c
@@ -43,7 +43,10 @@ extern "C" {
 
 #define WIN32_LEAN_AND_MEAN
 #ifndef __cplusplus
-#define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS 0
+  #define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS 0
+#endif
+#ifndef NOMINMAX
+  #define NOMINMAX
 #endif
 #include <windows.h>
 


### PR DESCRIPTION
Miniz started including windows.h from version 3.0.0 and on when compiling for Windows using MSVC.

windows.h header file is known to conflict with C++ std namespace by defining its own min/max macros. It is a common practice to disable these ancient macros in windows.h by declaring NOMINMAX macro prior to including windows.h in code.

While this issue does not affect miniz directly due to the fact that it is straight-C code and it does not use min/max from C++ std namespace, it does affect other projects like miniz-cpp which wrap and amalgamate miniz and then both compile in C++ mode and use min/max from std namespace.

It is therefore proposed to prefix inclusion of windows.h in miniz_zip.c by the following lines:

#ifndef NOMINMAX
#define NOMINMAX
#endif